### PR TITLE
docker compose up --build

### DIFF
--- a/Backend/.dockerignore
+++ b/Backend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+coverage
+.env
+.env.*
+npm-debug.log*
+.git
+.gitignore
+Dockerfile*
+README.md

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+CMD ["node", "dist/main"]

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -57,6 +57,20 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## Docker
+
+Build and run the backend with PostgreSQL from the repository root:
+
+```bash
+cd ..
+docker compose up --build
+```
+
+The compose stack starts:
+
+- `backend` on `http://localhost:3000/api`
+- `db` (PostgreSQL 16) on `localhost:5432`
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/README.md
+++ b/README.md
@@ -555,40 +555,47 @@ The API will be available at:
 
 ## 🐳 Running with Docker
 
-> Docker support coming soon. The following is the planned `docker-compose.yml` setup.
+The backend and PostgreSQL database are fully containerised with `docker-compose.yml`.
 
-```yaml
-version: '3.8'
-services:
-  api:
-    build: ./Backend
-    ports:
-      - "3000:3000"
-    environment:
-      - NODE_ENV=production
-      - DB_HOST=db
-    depends_on:
-      - db
+### Prerequisites
 
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: charicall
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - pg_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+- Docker Desktop (or Docker Engine + Compose)
 
-volumes:
-  pg_data:
-```
-
-Run with:
+### Step 1 — Configure Environment Variables
 
 ```bash
+cd Backend
+cp .env.example .env
+```
+
+`docker-compose.yml` loads `Backend/.env` and overrides `DB_HOST` to `db` so the backend can connect to the Postgres service container.
+
+### Step 2 — Build and Start Services
+
+```bash
+cd ..
 docker compose up --build
+```
+
+### Services
+
+| Service | URL/Port | Notes |
+|---|---|---|
+| Backend API | `http://localhost:3000/api` | NestJS production build running in container |
+| Swagger Docs | `http://localhost:3000/api/docs` | OpenAPI docs |
+| PostgreSQL | `localhost:5432` | Database persisted to Docker volume `pg_data` |
+
+### Useful Commands
+
+```bash
+# Start in detached mode
+docker compose up -d --build
+
+# Stop and remove containers
+docker compose down
+
+# Stop and remove containers + database volume
+docker compose down -v
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   backend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./Backend
+      dockerfile: Dockerfile
+    container_name: charicall-backend
+    restart: unless-stopped
+    env_file:
+      - ./Backend/.env
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    container_name: charicall-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: charicall
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d charicall"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pg_data:


### PR DESCRIPTION
Closes #70

---

Implemented and validated what I could in this environment for BE-28 Dockerization.

What’s in place now
docker-compose.yml is present and configured for:
backend service (builds from Backend/Dockerfile)
db service (postgres:16-alpine)
DB healthcheck + depends_on health gating
persistent volume pg_data
Backend/Dockerfile is multi-stage and production-oriented:
builder stage compiles NestJS
runtime stage installs prod deps + runs dist/main
Backend/.dockerignore exists to keep images lean.
Docker docs are present in both README.md and Backend/README.md.
Change made by me
Updated docker-compose.yml to remove the deprecated version key (Compose warns it is obsolete).
Test status
npm run test ✅ passes.
npm run test:e2e ❌ fails locally because PostgreSQL is unavailable (Unable to connect to the database).
I attempted to start DB via compose, but Docker daemon is not running/accessible in this machine session (pipe/docker_engine not found), so I could not complete integration verification here.