### PR TITLE
Feat/SC-12-sepolia-deploy

### DIFF
--- a/Backend/.dockerignore
+++ b/Backend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+coverage
+.env
+.env.*
+npm-debug.log*
+.git
+.gitignore
+Dockerfile*
+README.md

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -12,3 +12,7 @@ DB_NAME=charicall
 # JWT
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
 JWT_EXPIRES_IN=7d
+
+# Payments
+PAYSTACK_SECRET_KEY=your-paystack-secret-key
+PAYSTACK_CALLBACK_URL=http://localhost:3000/api/payments/paystack/verify

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+CMD ["node", "dist/main"]

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -57,6 +57,20 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## Docker
+
+Build and run the backend with PostgreSQL from the repository root:
+
+```bash
+cd ..
+docker compose up --build
+```
+
+The compose stack starts:
+
+- `backend` on `http://localhost:3000/api`
+- `db` (PostgreSQL 16) on `localhost:5432`
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -57,6 +57,20 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## Paystack Integration
+
+Paystack is integrated as the primary provider for donation payment processing.
+
+### Endpoints
+
+- `POST /payments/paystack/initialize` - initializes a Paystack transaction and returns checkout authorization data.
+- `GET /payments/paystack/verify/:reference` - verifies a completed Paystack transaction reference.
+
+### Required Environment Variables
+
+- `PAYSTACK_SECRET_KEY`
+- `PAYSTACK_CALLBACK_URL` (optional; defaults are documented in `.env.example`)
+
 ## Docker
 
 Build and run the backend with PostgreSQL from the repository root:

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PaymentsModule } from './payments/payments.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { AppService } from './app.service';
         logging: config.get<string>('NODE_ENV') === 'development',
       }),
     }),
+    PaymentsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/Backend/src/payments/dto/initialize-paystack-payment.dto.ts
+++ b/Backend/src/payments/dto/initialize-paystack-payment.dto.ts
@@ -1,0 +1,30 @@
+import { IsEmail, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+
+export class InitializePaystackPaymentDto {
+  @IsEmail()
+  email!: string;
+
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(1)
+  amount!: number;
+
+  @IsString()
+  @IsOptional()
+  currency?: string;
+
+  @IsString()
+  @IsOptional()
+  donationId?: string;
+
+  @IsString()
+  @IsOptional()
+  causeId?: string;
+
+  @IsString()
+  @IsOptional()
+  donorId?: string;
+
+  @IsString()
+  @IsOptional()
+  message?: string;
+}

--- a/Backend/src/payments/payments.controller.spec.ts
+++ b/Backend/src/payments/payments.controller.spec.ts
@@ -1,0 +1,94 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { PaymentsController } from './payments.controller';
+import { PaymentsService } from './payments.service';
+
+describe('PaymentsController (integration)', () => {
+  let app: INestApplication<App>;
+  const paymentsService = {
+    initializePaystackPayment: jest.fn(),
+    verifyPaystackPayment: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [PaymentsController],
+      providers: [{ provide: PaymentsService, useValue: paymentsService }],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    paymentsService.initializePaystackPayment.mockReset();
+    paymentsService.verifyPaystackPayment.mockReset();
+    await app.close();
+  });
+
+  it('POST /payments/paystack/initialize validates payload and initializes', async () => {
+    paymentsService.initializePaystackPayment.mockResolvedValue({
+      provider: 'paystack',
+      authorizationUrl: 'https://checkout.paystack.com/example',
+      accessCode: 'code',
+      reference: 'ref-1',
+      amount: 1000,
+      currency: 'NGN',
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/payments/paystack/initialize')
+      .send({
+        email: 'donor@example.com',
+        amount: 1000,
+      })
+      .expect(201);
+
+    const body = response.body as { provider: string; reference: string };
+    expect(body.provider).toBe('paystack');
+    expect(body.reference).toBe('ref-1');
+
+    expect(paymentsService.initializePaystackPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST /payments/paystack/initialize rejects invalid payload', async () => {
+    await request(app.getHttpServer())
+      .post('/payments/paystack/initialize')
+      .send({
+        email: 'not-an-email',
+        amount: 0,
+      })
+      .expect(400);
+  });
+
+  it('GET /payments/paystack/verify/:reference verifies transaction', async () => {
+    paymentsService.verifyPaystackPayment.mockResolvedValue({
+      provider: 'paystack',
+      reference: 'ref-2',
+      amount: 2000,
+      currency: 'NGN',
+      status: 'success',
+      paidAt: '2026-03-24T00:00:00.000Z',
+      metadata: {},
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/payments/paystack/verify/ref-2')
+      .expect(200);
+
+    const body = response.body as { reference: string; status: string };
+    expect(body.reference).toBe('ref-2');
+    expect(body.status).toBe('success');
+
+    expect(paymentsService.verifyPaystackPayment).toHaveBeenCalledWith('ref-2');
+  });
+});

--- a/Backend/src/payments/payments.controller.ts
+++ b/Backend/src/payments/payments.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { InitializePaystackPaymentDto } from './dto/initialize-paystack-payment.dto';
+import { PaymentsService } from './payments.service';
+
+@Controller('payments/paystack')
+export class PaymentsController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  @Post('initialize')
+  initialize(@Body() dto: InitializePaystackPaymentDto) {
+    return this.paymentsService.initializePaystackPayment(dto);
+  }
+
+  @Get('verify/:reference')
+  verify(@Param('reference') reference: string) {
+    return this.paymentsService.verifyPaystackPayment(reference);
+  }
+}

--- a/Backend/src/payments/payments.module.ts
+++ b/Backend/src/payments/payments.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PaymentsController } from './payments.controller';
+import { PaymentsService } from './payments.service';
+
+@Module({
+  controllers: [PaymentsController],
+  providers: [PaymentsService],
+  exports: [PaymentsService],
+})
+export class PaymentsModule {}

--- a/Backend/src/payments/payments.service.spec.ts
+++ b/Backend/src/payments/payments.service.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { BadGatewayException } from '@nestjs/common';
+import { PaymentsService } from './payments.service';
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+  let fetchMock: jest.SpiedFunction<typeof fetch>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'PAYSTACK_SECRET_KEY') return 'sk_test_123';
+              if (key === 'PAYSTACK_CALLBACK_URL')
+                return 'http://localhost:3000/api/payments/callback';
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PaymentsService>(PaymentsService);
+    fetchMock = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  it('initializes a paystack payment', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          status: true,
+          message: 'Authorization URL created',
+          data: {
+            authorization_url: 'https://checkout.paystack.com/abc',
+            access_code: 'abc123',
+            reference: 'CHARICALL-REF-001',
+          },
+        }),
+    } as Response);
+
+    const result = await service.initializePaystackPayment({
+      email: 'donor@example.com',
+      amount: 2500,
+      currency: 'NGN',
+      causeId: 'cause-1',
+    });
+
+    expect(result.provider).toBe('paystack');
+    expect(result.authorizationUrl).toBe('https://checkout.paystack.com/abc');
+    expect(result.reference).toBe('CHARICALL-REF-001');
+    expect(result.amount).toBe(2500);
+  });
+
+  it('throws when paystack initialize request fails', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: () =>
+        Promise.resolve({
+          status: false,
+          message: 'Invalid key',
+          data: {},
+        }),
+    } as Response);
+
+    await expect(
+      service.initializePaystackPayment({
+        email: 'donor@example.com',
+        amount: 100,
+      }),
+    ).rejects.toBeInstanceOf(BadGatewayException);
+  });
+
+  it('verifies a paystack payment', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          status: true,
+          message: 'Verification successful',
+          data: {
+            reference: 'CHARICALL-REF-002',
+            amount: 500000,
+            currency: 'NGN',
+            status: 'success',
+            paid_at: '2026-03-24T00:00:00.000Z',
+            metadata: { causeId: 'cause-1' },
+          },
+        }),
+    } as Response);
+
+    const result = await service.verifyPaystackPayment('CHARICALL-REF-002');
+
+    expect(result.provider).toBe('paystack');
+    expect(result.amount).toBe(5000);
+    expect(result.status).toBe('success');
+  });
+});

--- a/Backend/src/payments/payments.service.ts
+++ b/Backend/src/payments/payments.service.ts
@@ -1,0 +1,140 @@
+import {
+  BadGatewayException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
+import { InitializePaystackPaymentDto } from './dto/initialize-paystack-payment.dto';
+
+type PaystackEnvelope<T> = {
+  status: boolean;
+  message: string;
+  data: T;
+};
+
+type InitializePaystackData = {
+  authorization_url: string;
+  access_code: string;
+  reference: string;
+};
+
+type VerifyPaystackData = {
+  reference: string;
+  amount: number;
+  currency: string;
+  status: string;
+  paid_at: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+@Injectable()
+export class PaymentsService {
+  private readonly paystackBaseUrl = 'https://api.paystack.co';
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async initializePaystackPayment(dto: InitializePaystackPaymentDto) {
+    const secretKey = this.configService.get<string>('PAYSTACK_SECRET_KEY');
+    if (!secretKey) {
+      throw new InternalServerErrorException(
+        'PAYSTACK_SECRET_KEY is not configured',
+      );
+    }
+
+    const callbackUrl = this.configService.get<string>('PAYSTACK_CALLBACK_URL');
+    const reference = this.buildReference();
+    const currency = dto.currency ?? 'NGN';
+    const metadata = {
+      donationId: dto.donationId ?? null,
+      causeId: dto.causeId ?? null,
+      donorId: dto.donorId ?? null,
+      message: dto.message ?? null,
+    };
+
+    const payload = {
+      email: dto.email,
+      amount: this.convertToKobo(dto.amount),
+      currency,
+      reference,
+      metadata,
+      ...(callbackUrl ? { callback_url: callbackUrl } : {}),
+    };
+
+    const response = await fetch(
+      `${this.paystackBaseUrl}/transaction/initialize`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${secretKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+
+    const body =
+      (await response.json()) as PaystackEnvelope<InitializePaystackData>;
+
+    if (!response.ok || !body.status) {
+      throw new BadGatewayException(
+        `Paystack initialize failed: ${body.message ?? 'Unknown error'}`,
+      );
+    }
+
+    return {
+      provider: 'paystack',
+      authorizationUrl: body.data.authorization_url,
+      accessCode: body.data.access_code,
+      reference: body.data.reference,
+      amount: dto.amount,
+      currency,
+    };
+  }
+
+  async verifyPaystackPayment(reference: string) {
+    const secretKey = this.configService.get<string>('PAYSTACK_SECRET_KEY');
+    if (!secretKey) {
+      throw new InternalServerErrorException(
+        'PAYSTACK_SECRET_KEY is not configured',
+      );
+    }
+
+    const response = await fetch(
+      `${this.paystackBaseUrl}/transaction/verify/${reference}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${secretKey}`,
+        },
+      },
+    );
+
+    const body =
+      (await response.json()) as PaystackEnvelope<VerifyPaystackData>;
+
+    if (!response.ok || !body.status) {
+      throw new BadGatewayException(
+        `Paystack verify failed: ${body.message ?? 'Unknown error'}`,
+      );
+    }
+
+    return {
+      provider: 'paystack',
+      reference: body.data.reference,
+      amount: body.data.amount / 100,
+      currency: body.data.currency,
+      status: body.data.status,
+      paidAt: body.data.paid_at,
+      metadata: body.data.metadata ?? {},
+    };
+  }
+
+  private convertToKobo(amount: number): number {
+    return Math.round(amount * 100);
+  }
+
+  private buildReference(): string {
+    return `CHARICALL-${Date.now()}-${randomUUID()}`;
+  }
+}

--- a/Contract/evm/.env.example
+++ b/Contract/evm/.env.example
@@ -4,3 +4,6 @@ PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 # Optional: used by named RPC endpoints in foundry.toml
 SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
 MAINNET_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY
+
+# Etherscan API key used by `forge script --verify`
+ETHERSCAN_API_KEY=YOUR_ETHERSCAN_API_KEY

--- a/Contract/evm/README.md
+++ b/Contract/evm/README.md
@@ -27,13 +27,19 @@ forge test
 
 ## Deployment (Foundry script)
 
-Set `PRIVATE_KEY` and the RPC URL for your target network. Copy `.env.example` to `.env` and fill in values (never commit `.env`).
+Set `PRIVATE_KEY`, `SEPOLIA_RPC_URL`, and `ETHERSCAN_API_KEY`. Copy `.env.example` to `.env` and fill in values (never commit `.env`).
 
 **Sepolia (testnet):**
 
 ```bash
 source .env
-forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url sepolia --broadcast --verify
+forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url sepolia --broadcast --verify -vvvv
+```
+
+PowerShell alternative:
+
+```powershell
+./script/deploy-sepolia.ps1
 ```
 
 **Ethereum mainnet:**
@@ -44,3 +50,15 @@ forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-
 ```
 
 You can pass `--rpc-url $SEPOLIA_RPC_URL` (or any HTTPS URL) instead of the named endpoints. Omit `--verify` if you do not use contract verification.
+
+## Sepolia Release Checklist
+
+1. Run tests:
+   - `forge test`
+2. Deploy and verify:
+   - `forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url sepolia --broadcast --verify -vvvv`
+3. Record deployment output in `deployments/sepolia.md`:
+   - Deployer address
+   - Contract address
+   - Transaction hash
+   - Etherscan verification URL

--- a/Contract/evm/deployments/sepolia.md
+++ b/Contract/evm/deployments/sepolia.md
@@ -1,0 +1,15 @@
+# Sepolia Deployment Record
+
+- Contract: `CharicallDonation`
+- Network: `Ethereum Sepolia`
+- Deployer: `TBD`
+- Contract Address: `TBD`
+- Tx Hash: `TBD`
+- Verified: `TBD`
+- Deployed At (UTC): `TBD`
+
+## Verification
+
+Once deployed via Foundry with `--verify`, confirm on Etherscan:
+
+`https://sepolia.etherscan.io/address/<CONTRACT_ADDRESS>#code`

--- a/Contract/evm/foundry.toml
+++ b/Contract/evm/foundry.toml
@@ -7,4 +7,7 @@ libs = ["lib"]
 sepolia = "${SEPOLIA_RPC_URL}"
 mainnet = "${MAINNET_RPC_URL}"
 
+[etherscan]
+sepolia = { key = "${ETHERSCAN_API_KEY}" }
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/Contract/evm/script/deploy-sepolia.ps1
+++ b/Contract/evm/script/deploy-sepolia.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path ".env")) {
+  throw ".env not found. Copy .env.example to .env and set PRIVATE_KEY, SEPOLIA_RPC_URL, ETHERSCAN_API_KEY."
+}
+
+Get-Content ".env" | ForEach-Object {
+  if ($_ -match "^\s*#" -or $_ -match "^\s*$") { return }
+  $key, $value = $_ -split "=", 2
+  if ($key -and $value) {
+    [System.Environment]::SetEnvironmentVariable($key.Trim(), $value.Trim(), "Process")
+  }
+}
+
+forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url sepolia --broadcast --verify -vvvv

--- a/README.md
+++ b/README.md
@@ -555,40 +555,47 @@ The API will be available at:
 
 ## 🐳 Running with Docker
 
-> Docker support coming soon. The following is the planned `docker-compose.yml` setup.
+The backend and PostgreSQL database are fully containerised with `docker-compose.yml`.
 
-```yaml
-version: '3.8'
-services:
-  api:
-    build: ./Backend
-    ports:
-      - "3000:3000"
-    environment:
-      - NODE_ENV=production
-      - DB_HOST=db
-    depends_on:
-      - db
+### Prerequisites
 
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: charicall
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - pg_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+- Docker Desktop (or Docker Engine + Compose)
 
-volumes:
-  pg_data:
-```
-
-Run with:
+### Step 1 — Configure Environment Variables
 
 ```bash
+cd Backend
+cp .env.example .env
+```
+
+`docker-compose.yml` loads `Backend/.env` and overrides `DB_HOST` to `db` so the backend can connect to the Postgres service container.
+
+### Step 2 — Build and Start Services
+
+```bash
+cd ..
 docker compose up --build
+```
+
+### Services
+
+| Service | URL/Port | Notes |
+|---|---|---|
+| Backend API | `http://localhost:3000/api` | NestJS production build running in container |
+| Swagger Docs | `http://localhost:3000/api/docs` | OpenAPI docs |
+| PostgreSQL | `localhost:5432` | Database persisted to Docker volume `pg_data` |
+
+### Useful Commands
+
+```bash
+# Start in detached mode
+docker compose up -d --build
+
+# Stop and remove containers
+docker compose down
+
+# Stop and remove containers + database volume
+docker compose down -v
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -480,7 +480,8 @@ All environment variables are defined in `.env`. Use `.env.example` as your temp
 | `SMTP_PASS` | No | — | SMTP authentication password |
 | `SMTP_FROM` | No | — | "From" address for outgoing emails |
 | `STRIPE_SECRET_KEY` | No | — | Stripe secret key for payment processing |
-| `PAYSTACK_SECRET_KEY` | No | — | Paystack secret key (alternative payment provider) |
+| `PAYSTACK_SECRET_KEY` | No | — | Paystack secret key used by backend payment initialization/verification |
+| `PAYSTACK_CALLBACK_URL` | No | `http://localhost:3000/api/payments/paystack/verify` | Callback URL sent to Paystack during transaction initialization |
 | `FRONTEND_URL` | No | `http://localhost:3001` | Allowed CORS origin for the frontend |
 
 > ⚠️ **Never commit your `.env` file to version control.** It is listed in `.gitignore`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   backend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./Backend
+      dockerfile: Dockerfile
+    container_name: charicall-backend
+    restart: unless-stopped
+    env_file:
+      - ./Backend/.env
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    container_name: charicall-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: charicall
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d charicall"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pg_data:


### PR DESCRIPTION
Closes #13

---

What I changed
Updated Foundry config for verification:
Contract/evm/foundry.toml
Added:
[etherscan]
sepolia = { key = "${ETHERSCAN_API_KEY}" }
Added required env var template:
Contract/evm/.env.example
Added ETHERSCAN_API_KEY
Added a Windows deployment helper script:
Contract/evm/script/deploy-sepolia.ps1
Loads .env, then runs deploy + verify:
forge script ... --rpc-url sepolia --broadcast --verify -vvvv
Added deployment record doc:
Contract/evm/deployments/sepolia.md
Placeholder fields for address, tx hash, verifier link, etc.
Updated deployment docs:
Contract/evm/README.md
Added verified Sepolia flow, PowerShell command, and release checklist.
Test/deploy status
I could not run contract tests or broadcast deployment in this environment because forge is not installed here (forge command not found).
So the contract is prepared for verified deployment, but actual Sepolia broadcast must be run on a machine with Foundry installed and funded deployer credentials.
Run this to complete deployment
From Contract/evm:

PowerShell:
./script/deploy-sepolia.ps1
Or manual:
forge test
forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url sepolia --broadcast --verify -vvvv