### PR TITLE
SC-19: add DONATION_VERSION and upgrade docs

### DIFF
--- a/Contract/evm/README.md
+++ b/Contract/evm/README.md
@@ -5,6 +5,7 @@ Solidity contracts for on-chain donation tracking, built with [Foundry](https://
 ## Contracts
 
 - **`CharicallDonation`** — Per-cause targets and raised totals in wei. Emits **`CauseClosed`** the first time a cause’s cumulative donations meet or exceed its target.
+- **`DONATION_VERSION`** — Public semantic version constant for tracking contract interface upgrades across deployments.
 
 ## Prerequisites
 

--- a/Contract/evm/src/CharicallDonation.sol
+++ b/Contract/evm/src/CharicallDonation.sol
@@ -5,6 +5,9 @@ pragma solidity ^0.8.20;
 /// @notice On-chain donation ledger for Charicall causes. Totals per cause are tracked in wei.
 /// @dev `CauseClosed` fires exactly once when a cause first reaches or exceeds its funding target.
 contract CharicallDonation {
+    /// @notice Semantic version for the deployed donation contract interface.
+    string public constant DONATION_VERSION = "1.0.0";
+
     struct Cause {
         uint256 targetAmount;
         uint256 raisedAmount;

--- a/Contract/evm/test/CharicallDonation.t.sol
+++ b/Contract/evm/test/CharicallDonation.t.sol
@@ -22,6 +22,10 @@ contract CharicallDonationTest is Test {
         donation.createCause(CAUSE_ID, TARGET);
     }
 
+    function test_exposesDonationVersion() public {
+        assertEq(donation.DONATION_VERSION(), "1.0.0");
+    }
+
     function test_emitsCauseClosed_whenTotalMeetsTarget() public {
         vm.deal(donor, TARGET);
 


### PR DESCRIPTION
## Description
Add a public contract version constant so the donation interface can be tracked explicitly across future upgrades.

Closes #20

## Changes proposed

### What were you told to do?
Version the contract interface so future upgrades are clearly tracked, with tests and documentation updates where applicable.

### What did I do?
#### Contract versioning
- Added a public `DONATION_VERSION` semantic version constant to `CharicallDonation`.
- Documented the version constant with NatSpec so the interface intent is clear in the contract source.

#### Tests and docs
- Added a Foundry unit test that asserts the version constant is exposed as expected.
- Updated the EVM README to document the new upgrade-tracking constant.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with `forge test` in `Contract/evm` on March 24, 2026. Result: 6 tests passed, 0 failed, 0 skipped.