### PR TITLE
SC-22: implement donation anonymisation

### DIFF
--- a/Contract/evm/README.md
+++ b/Contract/evm/README.md
@@ -5,6 +5,7 @@ Solidity contracts for on-chain donation tracking, built with [Foundry](https://
 ## Contracts
 
 - **`CharicallDonation`** — Per-cause targets and raised totals in wei. Emits **`CauseClosed`** the first time a cause’s cumulative donations meet or exceed its target.
+- Anonymous donations persist a `DonationRecord` with `donor = address(0)` so on-chain storage does not reveal the donor wallet.
 
 ## Prerequisites
 
@@ -24,6 +25,8 @@ forge build
 ```bash
 forge test
 ```
+
+Coverage in this package includes anonymous donation storage so regressions around donor redaction are caught in CI.
 
 ## Deployment (Foundry script)
 

--- a/Contract/evm/src/CharicallDonation.sol
+++ b/Contract/evm/src/CharicallDonation.sol
@@ -11,12 +11,21 @@ contract CharicallDonation {
         bool goalReachedEmitted;
     }
 
+    struct DonationRecord {
+        address donor;
+        uint256 amount;
+        bool isAnonymous;
+    }
+
     address public owner;
 
     mapping(uint256 causeId => Cause) public causes;
+    mapping(uint256 causeId => DonationRecord[]) private donationRecords;
 
     /// @notice Emitted for every donation received for a cause.
-    event Donation(uint256 indexed causeId, address indexed donor, uint256 amount, uint256 newTotalRaised);
+    event Donation(
+        uint256 indexed causeId, address indexed donor, uint256 amount, uint256 newTotalRaised, bool isAnonymous
+    );
 
     /// @notice Emitted once when `raisedAmount` first meets or exceeds `targetAmount` for a cause.
     /// @param causeId The cause identifier.
@@ -49,12 +58,40 @@ contract CharicallDonation {
 
     /// @notice Accepts a native-token donation for a cause and emits `CauseClosed` when the goal is first reached.
     function donate(uint256 causeId) external payable {
+        _donate(causeId, false);
+    }
+
+    /// @notice Accepts a native-token donation for a cause without persisting the donor address on-chain.
+    function donateAnonymous(uint256 causeId) external payable {
+        _donate(causeId, true);
+    }
+
+    /// @notice Returns the number of donation records stored for a cause.
+    function donationCount(uint256 causeId) external view returns (uint256) {
+        return donationRecords[causeId].length;
+    }
+
+    /// @notice Returns a stored donation record for a cause.
+    function getDonation(uint256 causeId, uint256 index)
+        external
+        view
+        returns (address donor, uint256 amount, bool isAnonymous)
+    {
+        DonationRecord storage record = donationRecords[causeId][index];
+        return (record.donor, record.amount, record.isAnonymous);
+    }
+
+    function _donate(uint256 causeId, bool isAnonymous) internal {
         if (msg.value == 0) revert ZeroDonation();
         Cause storage c = causes[causeId];
         if (c.targetAmount == 0) revert UnknownCause();
 
         c.raisedAmount += msg.value;
-        emit Donation(causeId, msg.sender, msg.value, c.raisedAmount);
+        address donorToStore = isAnonymous ? address(0) : msg.sender;
+        donationRecords[causeId].push(
+            DonationRecord({donor: donorToStore, amount: msg.value, isAnonymous: isAnonymous})
+        );
+        emit Donation(causeId, donorToStore, msg.value, c.raisedAmount, isAnonymous);
 
         if (!c.goalReachedEmitted && c.raisedAmount >= c.targetAmount) {
             c.goalReachedEmitted = true;

--- a/Contract/evm/test/CharicallDonation.t.sol
+++ b/Contract/evm/test/CharicallDonation.t.sol
@@ -12,7 +12,9 @@ contract CharicallDonationTest is Test {
     uint256 internal constant CAUSE_ID = 1;
     uint256 internal constant TARGET = 1 ether;
 
-    event Donation(uint256 indexed causeId, address indexed donor, uint256 amount, uint256 newTotalRaised);
+    event Donation(
+        uint256 indexed causeId, address indexed donor, uint256 amount, uint256 newTotalRaised, bool isAnonymous
+    );
     event CauseClosed(uint256 indexed causeId, uint256 totalRaised, uint256 targetAmount);
 
     function setUp() public {
@@ -20,6 +22,37 @@ contract CharicallDonationTest is Test {
         donation = new CharicallDonation();
         vm.prank(owner);
         donation.createCause(CAUSE_ID, TARGET);
+    }
+
+    function test_storesDonorAddress_forPublicDonations() public {
+        vm.deal(donor, 0.25 ether);
+
+        vm.prank(donor);
+        donation.donate{value: 0.25 ether}(CAUSE_ID);
+
+        assertEq(donation.donationCount(CAUSE_ID), 1);
+
+        (address storedDonor, uint256 amount, bool isAnonymous) = donation.getDonation(CAUSE_ID, 0);
+        assertEq(storedDonor, donor);
+        assertEq(amount, 0.25 ether);
+        assertFalse(isAnonymous);
+    }
+
+    function test_zeroesOutDonorAddress_forAnonymousDonations() public {
+        vm.deal(donor, 0.25 ether);
+
+        vm.expectEmit(true, true, true, true);
+        emit Donation(CAUSE_ID, address(0), 0.25 ether, 0.25 ether, true);
+
+        vm.prank(donor);
+        donation.donateAnonymous{value: 0.25 ether}(CAUSE_ID);
+
+        assertEq(donation.donationCount(CAUSE_ID), 1);
+
+        (address storedDonor, uint256 amount, bool isAnonymous) = donation.getDonation(CAUSE_ID, 0);
+        assertEq(storedDonor, address(0));
+        assertEq(amount, 0.25 ether);
+        assertTrue(isAnonymous);
     }
 
     function test_emitsCauseClosed_whenTotalMeetsTarget() public {


### PR DESCRIPTION
## Description
Implement anonymous on-chain donation storage by redacting donor addresses when donors choose to stay anonymous.

Closes #23

## Changes proposed

### What were you told to do?
When a donation is anonymous, zero out the donor address in storage, and include tests plus documentation updates where applicable.

### What did I do?
#### Donation storage updates
- Added per-cause `DonationRecord` storage so donation entries can be inspected on-chain.
- Added `donateAnonymous` to persist anonymous donations with `donor = address(0)`.
- Preserved the existing `donate` flow for public donations and exposed read helpers for donation count and stored donation records.

#### Privacy and verification coverage
- Emitted anonymous donation events with the redacted donor address so public traces align with stored state.
- Added Foundry tests for public donation storage, anonymous donation redaction, and the existing funding-goal flows.
- Updated the EVM README to document the redaction behavior.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with `forge test` in `Contract/evm` on March 24, 2026. Result: 7 tests passed, 0 failed, 0 skipped.