### PR TITLE
SC-23: add Base and Polygon Foundry support

### DIFF
--- a/Contract/evm/.env.example
+++ b/Contract/evm/.env.example
@@ -3,4 +3,6 @@ PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # Optional: used by named RPC endpoints in foundry.toml
 SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
+BASE_SEPOLIA_RPC_URL=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
+POLYGON_MUMBAI_RPC_URL=https://polygon-mumbai.g.alchemy.com/v2/YOUR_KEY
 MAINNET_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY

--- a/Contract/evm/README.md
+++ b/Contract/evm/README.md
@@ -36,6 +36,20 @@ source .env
 forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url sepolia --broadcast --verify
 ```
 
+**Base Sepolia (testnet):**
+
+```bash
+source .env
+forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url base_sepolia --broadcast --verify
+```
+
+**Polygon Mumbai (testnet):**
+
+```bash
+source .env
+forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url polygon_mumbai --broadcast --verify
+```
+
 **Ethereum mainnet:**
 
 ```bash
@@ -43,4 +57,4 @@ source .env
 forge script script/DeployCharicallDonation.s.sol:DeployCharicallDonation --rpc-url mainnet --broadcast --verify
 ```
 
-You can pass `--rpc-url $SEPOLIA_RPC_URL` (or any HTTPS URL) instead of the named endpoints. Omit `--verify` if you do not use contract verification.
+You can pass `--rpc-url $SEPOLIA_RPC_URL` (or any HTTPS URL) instead of the named endpoints. Omit `--verify` if you do not use contract verification. The named endpoints currently cover Ethereum Sepolia, Base Sepolia, Polygon Mumbai, and Ethereum mainnet.

--- a/Contract/evm/foundry.toml
+++ b/Contract/evm/foundry.toml
@@ -5,6 +5,8 @@ libs = ["lib"]
 
 [rpc_endpoints]
 sepolia = "${SEPOLIA_RPC_URL}"
+base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
+polygon_mumbai = "${POLYGON_MUMBAI_RPC_URL}"
 mainnet = "${MAINNET_RPC_URL}"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/Contract/evm/test/FoundryConfig.t.sol
+++ b/Contract/evm/test/FoundryConfig.t.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+contract FoundryConfigTest is Test {
+    function test_rpcAliasesResolveForSupportedNetworks() public {
+        vm.setEnv("SEPOLIA_RPC_URL", "https://sepolia.example");
+        vm.setEnv("BASE_SEPOLIA_RPC_URL", "https://base-sepolia.example");
+        vm.setEnv("POLYGON_MUMBAI_RPC_URL", "https://polygon-mumbai.example");
+        vm.setEnv("MAINNET_RPC_URL", "https://mainnet.example");
+
+        assertEq(vm.rpcUrl("sepolia"), "https://sepolia.example");
+        assertEq(vm.rpcUrl("base_sepolia"), "https://base-sepolia.example");
+        assertEq(vm.rpcUrl("polygon_mumbai"), "https://polygon-mumbai.example");
+        assertEq(vm.rpcUrl("mainnet"), "https://mainnet.example");
+    }
+}


### PR DESCRIPTION
## Description
Add Foundry configuration and deployment documentation for Base Sepolia and Polygon Mumbai alongside the existing Ethereum endpoints.

Closes #24

## Changes proposed

### What were you told to do?
Configure Foundry for deployment to Base Sepolia and Polygon Mumbai, with tests and documentation updates where applicable.

### What did I do?
#### Foundry network configuration
- Added named RPC endpoints for `base_sepolia` and `polygon_mumbai` in `foundry.toml`.
- Extended `.env.example` with the matching environment variables needed to deploy to those networks.

#### Tests and deployment docs
- Added a Foundry test that verifies the configured RPC aliases resolve correctly from environment variables.
- Updated the EVM README with deployment commands for Base Sepolia and Polygon Mumbai.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with `forge test` in `Contract/evm` on March 24, 2026. Result: 6 tests passed, 0 failed, 0 skipped.