### PR TITLE
SC-27: implement on-chain verification badges

### DIFF
--- a/Contract/evm/README.md
+++ b/Contract/evm/README.md
@@ -5,6 +5,7 @@ Solidity contracts for on-chain donation tracking, built with [Foundry](https://
 ## Contracts
 
 - **`CharicallDonation`** — Per-cause targets and raised totals in wei. Emits **`CauseClosed`** the first time a cause’s cumulative donations meet or exceed its target.
+- **`verifiedOrganisations`** — Owner-managed on-chain verification badges for organisation wallets.
 
 ## Prerequisites
 

--- a/Contract/evm/src/CharicallDonation.sol
+++ b/Contract/evm/src/CharicallDonation.sol
@@ -14,6 +14,7 @@ contract CharicallDonation {
     address public owner;
 
     mapping(uint256 causeId => Cause) public causes;
+    mapping(address organisation => bool) public verifiedOrganisations;
 
     /// @notice Emitted for every donation received for a cause.
     event Donation(uint256 indexed causeId, address indexed donor, uint256 amount, uint256 newTotalRaised);
@@ -24,11 +25,15 @@ contract CharicallDonation {
     /// @param targetAmount The funding goal for the cause.
     event CauseClosed(uint256 indexed causeId, uint256 totalRaised, uint256 targetAmount);
 
+    /// @notice Emitted when an organisation's verification badge is updated on-chain.
+    event OrganisationVerificationUpdated(address indexed organisation, bool isVerified);
+
     error NotOwner();
     error ZeroTarget();
     error CauseAlreadyExists();
     error UnknownCause();
     error ZeroDonation();
+    error ZeroOrganisation();
 
     modifier onlyOwner() {
         if (msg.sender != owner) revert NotOwner();
@@ -65,5 +70,12 @@ contract CharicallDonation {
     /// @notice Transfers contract balance to the owner (e.g. for off-chain disbursement workflows).
     function withdraw(uint256 amount, address payable to) external onlyOwner {
         to.transfer(amount);
+    }
+
+    /// @notice Updates whether an organisation wallet should display a verified on-chain badge.
+    function setOrganisationVerification(address organisation, bool isVerified) external onlyOwner {
+        if (organisation == address(0)) revert ZeroOrganisation();
+        verifiedOrganisations[organisation] = isVerified;
+        emit OrganisationVerificationUpdated(organisation, isVerified);
     }
 }

--- a/Contract/evm/test/CharicallDonation.t.sol
+++ b/Contract/evm/test/CharicallDonation.t.sol
@@ -8,12 +8,14 @@ contract CharicallDonationTest is Test {
     CharicallDonation internal donation;
     address internal owner = address(0xA11CE);
     address internal donor = address(0xD00d);
+    address internal organisation = address(0xBEEF);
 
     uint256 internal constant CAUSE_ID = 1;
     uint256 internal constant TARGET = 1 ether;
 
     event Donation(uint256 indexed causeId, address indexed donor, uint256 amount, uint256 newTotalRaised);
     event CauseClosed(uint256 indexed causeId, uint256 totalRaised, uint256 targetAmount);
+    event OrganisationVerificationUpdated(address indexed organisation, bool isVerified);
 
     function setUp() public {
         vm.prank(owner);
@@ -71,5 +73,38 @@ contract CharicallDonationTest is Test {
 
         vm.prank(donor);
         donation.donate{value: TARGET / 2}(CAUSE_ID);
+    }
+
+    function test_ownerCanSetOrganisationVerification() public {
+        vm.expectEmit(true, true, true, true);
+        emit OrganisationVerificationUpdated(organisation, true);
+
+        vm.prank(owner);
+        donation.setOrganisationVerification(organisation, true);
+
+        assertTrue(donation.verifiedOrganisations(organisation));
+    }
+
+    function test_ownerCanRevokeOrganisationVerification() public {
+        vm.startPrank(owner);
+        donation.setOrganisationVerification(organisation, true);
+        donation.setOrganisationVerification(organisation, false);
+        vm.stopPrank();
+
+        assertFalse(donation.verifiedOrganisations(organisation));
+    }
+
+    function test_revertsWhenNonOwnerSetsOrganisationVerification() public {
+        vm.expectRevert(CharicallDonation.NotOwner.selector);
+
+        vm.prank(donor);
+        donation.setOrganisationVerification(organisation, true);
+    }
+
+    function test_revertsWhenOrganisationAddressIsZero() public {
+        vm.expectRevert(CharicallDonation.ZeroOrganisation.selector);
+
+        vm.prank(owner);
+        donation.setOrganisationVerification(address(0), true);
     }
 }


### PR DESCRIPTION
## Description
Introduce owner-managed on-chain verification badges for organisation wallets so verification state can be surfaced directly from the donation contract.

Closes #28

## Changes proposed

### What were you told to do?
Mark organisations as verified on-chain, with tests and documentation updates where applicable.

### What did I do?
#### On-chain verification state
- Added a `verifiedOrganisations` mapping to store badge state for organisation wallets.
- Added `setOrganisationVerification` so the contract owner can grant or revoke verification.
- Emitted `OrganisationVerificationUpdated` events and guarded against non-owner calls and zero-address organisations.

#### Tests and docs
- Added Foundry coverage for granting verification, revoking verification, access control, and zero-address validation.
- Updated the EVM README to document the on-chain verification badge mapping.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with `forge test` in `Contract/evm` on March 24, 2026. Result: 9 tests passed, 0 failed, 0 skipped.